### PR TITLE
Link statically against some libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,12 @@ LD=c++
 .PATH: $(SRCDIR)
 
 DLIBS=	-levent -levent_core -levent_pthreads -levent_openssl \
-	-lpq -lyaml-cpp -lfmt \
-	-l boost_system
+	-lyaml-cpp
+
+SLIBS=	/usr/local/lib/libboost_system.a \
+	/usr/local/lib/libfmt.so \
+	/usr/local/lib/libpq.a \
+	/usr/local/lib/libintl.a
 
 UNAME_S := $(shell uname -s)
 UNAME_R := $(shell uname -r)
@@ -47,7 +51,7 @@ all: testtool
 
 testtool: $(OBJECTS)
 	@echo $(OS)
-	$(LD) $(LDFLAGS) $(OBJECTS) $(DLIBS) -o $@
+	$(LD) $(LDFLAGS) $(OBJECTS) $(DLIBS) $(SLIBS) -o $@
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.cpp
 	$(CXX) $(CPPFLAGS) -c $< -o $(OBJDIR)/$*.o

--- a/bsd_port/Makefile
+++ b/bsd_port/Makefile
@@ -9,11 +9,11 @@ COMMENT=	Testtool checks health of loadbalanced services.
 USES=		gmake
 
 LIB_DEPENDS=	libevent-2.1.so.6:devel/libevent \
-		libpq.so.5:databases/postgresql93-client \
 		libyaml-cpp.so:devel/yaml-cpp \
-		libboost_system.so:devel/boost-libs
 
-BUILD_DEPENDS=	libfmt>=0:devel/libfmt
+BUILD_DEPENDS=	libfmt>=0:devel/libfmt \
+		libpq.so.5:databases/postgresql93-client \
+		libboost_system.so:devel/boost-libs
 
 PLIST_FILES=	/usr/local/sbin/testtool \
 		/usr/local/etc/rc.d/testtool


### PR DESCRIPTION
This does not seem like fully correct aproach but at least removes
dependency on versions of boost, postgres, fmt and intl libraries.