### PR TITLE
Allow testtool to make coredumps

### DIFF
--- a/rc/testtool_freebsd
+++ b/rc/testtool_freebsd
@@ -20,7 +20,7 @@ pidfile_testtool="/var/run/${name}_testtool.pid"
 
 command="/usr/local/sbin/testtool"
 procname="/usr/sbin/daemon"
-start_cmd="${procname} -r -P ${pidfile} -p ${pidfile_testtool} -f -c ${command}"
+start_cmd="${procname} -u root -r -P ${pidfile} -p ${pidfile_testtool} -f -c ${command}"
 
 load_rc_config $name
 


### PR DESCRIPTION
When starting testtool via sudo i.e. `sudo service testtool start`, sudo sets a 0B limit on core dumps. Daemon(8) won't restore the limit unless switch to a user happens. Testtool must run as root so we never cared to switch the user. Now we switch root to root and we get core dumps.