### PR TITLE
Rename finalize method for ping Healthcheck

### DIFF
--- a/src/healthcheck_ping.cpp
+++ b/src/healthcheck_ping.cpp
@@ -289,7 +289,7 @@ void Healthcheck_ping::callback(evutil_socket_t socket_fd, short what,
 ///
 /// Due to lack of possibility to use typical libevent timeout mechanism on raw
 /// sockets, it is necessary to check timeout of this healthcheck manually.
-void Healthcheck_ping::finalize_result() {
+void Healthcheck_ping::finalize() {
   struct timespec now;
   string message;
 

--- a/src/healthcheck_ping.h
+++ b/src/healthcheck_ping.h
@@ -58,7 +58,7 @@ public:
   int schedule_healthcheck(struct timespec *now);
   static int initialize();
   static void destroy();
-  void finalize_result();
+  void finalize();
 
 protected:
   void end_check(HealthcheckResult result, string message);


### PR DESCRIPTION
It seems like the function in the Healthcheck class was renamed from
finalize_result() to finalize() at some point, but was forgotten on the
Healthcheck_ping class.

This caused ping health checks to never timeout when the host was
failing, causing the hosts to never be claimed as down.