### PR TITLE
Add functions for killing states on FreeBSD 15

### DIFF
--- a/src/pfctl.cpp
+++ b/src/pfctl.cpp
@@ -164,6 +164,8 @@ bool pf_kill_src_nodes_to(string *address) {
 
 bool pf_kill_states_to_rdr(string *table, string *address) {
   vector<string> cmd;
+
+#if defined(__FreeBSD__) && __FreeBSD_version < 1500000
   cmd.push_back("-k");
   cmd.push_back("table");
   cmd.push_back("-k");
@@ -176,6 +178,17 @@ bool pf_kill_states_to_rdr(string *table, string *address) {
   cmd.push_back("kill");
   cmd.push_back("-k");
   cmd.push_back("rststates");
+#else
+  cmd.push_back("-k");
+  cmd.push_back("label");
+  cmd.push_back("-k");
+  cmd.push_back(*table);
+  cmd.push_back("-k");
+  cmd.push_back("gateway");
+  cmd.push_back("-k");
+  cmd.push_back(*address);
+  cmd.push_back("-I");
+#endif
 
   return pfctl_run_command(&cmd, NULL);
 }

--- a/src/pfctl.cpp
+++ b/src/pfctl.cpp
@@ -299,7 +299,7 @@ bool pf_sync_table(string table, SyncedLbNode *synced_lb_nodes) {
     return false;
 
   // Rebalance table if new hosts are added. Kill src_nodes to old entries
-  if (to_add.size())
+  if (!to_add.empty())
     pf_table_rebalance(&table, &to_add);
 
   return true;

--- a/src/pfctl.cpp
+++ b/src/pfctl.cpp
@@ -109,6 +109,7 @@ bool pf_table_del(string *table, set<string> *addresses) {
   return pfctl_run_command(&cmd, NULL);
 }
 
+#if defined(__FreeBSD__) && __FreeBSD_version < 1500000
 bool pf_kill_src_nodes_to(string *table, string *address, bool with_states) {
   vector<string> cmd;
   cmd.push_back("-K");
@@ -128,6 +129,38 @@ bool pf_kill_src_nodes_to(string *table, string *address, bool with_states) {
 
   return pfctl_run_command(&cmd, NULL);
 }
+#else
+bool pf_kill_src_nodes_to(string *address) {
+  //
+  // On FreeBSD 15 we don't have the universal killer for source nodes.
+  // Use the normal kill pfctl command and kill hosts by redirection address.
+  // Table name is not checked. Hopefully we don't share LB Nodes between
+  // LB Pools.
+  //
+  // TODO: Move the IOCTL for killing source nodes to Netlink so that we can
+  //       migrate the whole thing to Netlink and re-implement the missing
+  //       functionality without having to patch pfctl.
+
+  vector<string> cmd_4;
+  vector<string> cmd_6;
+  bool ret_4;
+  bool ret_6;
+
+  cmd_4.push_back("-K");
+  cmd_4.push_back("0.0.0.0");
+  cmd_4.push_back("-K");
+  cmd_4.push_back(*address);
+  ret_4 = pfctl_run_command(&cmd_4, NULL);
+
+  cmd_6.push_back("-K");
+  cmd_6.push_back("::/0");
+  cmd_6.push_back("-K");
+  cmd_6.push_back(*address);
+  ret_6 =  pfctl_run_command(&cmd_4, NULL);
+
+  return (ret_4 && ret_6);
+}
+#endif
 
 bool pf_kill_states_to_rdr(string *table, string *address) {
   vector<string> cmd;
@@ -223,7 +256,11 @@ bool pf_table_rebalance(string *table, set<string> *skip_addresses) {
 
   for (auto address : addresses) {
     if (skip_addresses->find(address) == skip_addresses->end()) {
+#if defined(__FreeBSD__) && __FreeBSD_version < 1500000
       ret = pf_kill_src_nodes_to(table, &address, false);
+#else
+      ret = pf_kill_src_nodes_to(&address);
+#endif
       if (!ret) {
         return false;
       }

--- a/src/pfctl.cpp
+++ b/src/pfctl.cpp
@@ -141,24 +141,18 @@ bool pf_kill_src_nodes_to(string *address) {
   //       migrate the whole thing to Netlink and re-implement the missing
   //       functionality without having to patch pfctl.
 
-  vector<string> cmd_4;
-  vector<string> cmd_6;
-  bool ret_4;
-  bool ret_6;
+  vector<string> cmd;
 
-  cmd_4.push_back("-K");
-  cmd_4.push_back("0.0.0.0");
-  cmd_4.push_back("-K");
-  cmd_4.push_back(*address);
-  ret_4 = pfctl_run_command(&cmd_4, NULL);
+  cmd.push_back("-K");
+  if (address->find(":") != std::string::npos) {
+    cmd.push_back("::/0");
+  } else {
+    cmd.push_back("0.0.0.0");
+  }
+  cmd.push_back("-K");
+  cmd.push_back(*address);
 
-  cmd_6.push_back("-K");
-  cmd_6.push_back("::/0");
-  cmd_6.push_back("-K");
-  cmd_6.push_back(*address);
-  ret_6 =  pfctl_run_command(&cmd_4, NULL);
-
-  return (ret_4 && ret_6);
+  return pfctl_run_command(&cmd, NULL);
 }
 #endif
 

--- a/src/pfctl.cpp
+++ b/src/pfctl.cpp
@@ -19,6 +19,10 @@
 #include <string>
 #include <sys/wait.h>
 
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#endif
+
 #include "msg.h"
 #include "pfctl.h"
 #include "pfctl_worker.h"

--- a/src/pfctl.cpp
+++ b/src/pfctl.cpp
@@ -333,17 +333,21 @@ bool pf_sync_table(string table, SyncedLbNode *synced_lb_nodes) {
       if (to_del.count(lb_node_ip_address) == 0)
         continue;
 
+#if defined(__FreeBSD__) && __FreeBSD_version < 1500000
       // Kill src_nodes. And linked states if necessary.
       pf_kill_src_nodes_to(&table, &lb_node_ip_address, with_states);
+#endif
 
       if (with_states) {
         // Kill unlinked states if necessary.
         pf_kill_states_to_rdr(&table, &lb_node_ip_address);
 
+#if defined(__FreeBSD__) && __FreeBSD_version < 1500000
         // Kill nodes again, there might be some which were created after last
         // kill due to belonging to states with deferred src_nodes. See
         // TECH-6711 and around.
         pf_kill_src_nodes_to(&table, &lb_node_ip_address, true);
+#endif
       }
     }
   }

--- a/src/pfctl.h
+++ b/src/pfctl.h
@@ -18,11 +18,16 @@ using namespace std;
 bool pfctl_run_command(vector<string> *args, vector<string> *lines);
 bool pf_table_add(string *table, set<string> *addresses);
 bool pf_table_del(string *table, set<string> *addresses);
-bool pf_kill_src_nodes_to(string *table, string *address, bool with_states);
 bool pf_kill_states_to_rdr(string *table, string *address);
 bool pf_get_table(string table, set<string> *result);
 bool pf_is_in_table(string *table, string *address, bool *answer);
 bool pf_table_rebalance(string *table, set<string> *skip_addresses);
 bool pf_sync_table(string table, SyncedLbNode *synced_lb_nodes);
+
+#if defined(__FreeBSD__) && __FreeBSD_version < 1500000
+bool pf_kill_src_nodes_to(string *table, string *address, bool with_states);
+#else
+bool pf_kill_src_nodes_to(string *table, string *address);
+#endif
 
 #endif


### PR DESCRIPTION
On FreeBSD 15 we have finally ported from OpenBSD the check for the target found in the source node being valid. So there is no need to kill the source nodes when killing states.

Killing of source nodes for rebalancing is fine, though.

For killing of states use the new -I option for injecting RSTs.